### PR TITLE
docs: add securitycenter prefix to samples, wrap published samples and repl…

### DIFF
--- a/samples/snippets/snippets_findings.py
+++ b/samples/snippets/snippets_findings.py
@@ -19,6 +19,7 @@
 
 def create_source(organization_id):
     """Create a new findings source. """
+    # [START securitycenter_create_source]
     # [START create_source]
     from google.cloud import securitycenter
 
@@ -38,10 +39,12 @@ def create_source(organization_id):
     )
     print("Created Source: {}".format(created.name))
     # [END create_source]
+    # [END securitycenter_create_source]
 
 
 def get_source(source_name):
     """Gets an existing source."""
+    # [START securitycenter_get_source]
     # [START get_source]
     from google.cloud import securitycenter
 
@@ -57,11 +60,13 @@ def get_source(source_name):
 
     print("Source: {}".format(source))
     # [END get_source]
+    # [END securitycenter_get_source]
     return source
 
 
 def update_source(source_name):
     """Updates a source's display name."""
+    # [START securitycenter_update_source]
     # [START update_source]
     from google.cloud import securitycenter
     from google.protobuf import field_mask_pb2
@@ -85,12 +90,14 @@ def update_source(source_name):
     )
     print("Updated Source: {}".format(updated))
     # [END update_source]
+    # [END securitycenter_update_source]
     return updated
 
 
 def add_user_to_source(source_name):
     """Gives a user findingsEditor permission to the source."""
     user_email = "csccclienttest@gmail.com"
+    # [START securitycenter_update_source_iam]
     # [START update_source_iam]
     from google.cloud import securitycenter
     from google.iam.v1 import policy_pb2
@@ -125,12 +132,14 @@ def add_user_to_source(source_name):
     print("Updated Policy: {}".format(updated))
 
     # [END update_source_iam]
+    # [END securitycenter_update_source_iam]
     return binding, updated
 
 
 def list_source(organization_id):
     """Lists finding sources."""
     i = -1
+    # [START securitycenter_list_sources]
     # [START list_sources]
     from google.cloud import securitycenter
 
@@ -144,11 +153,13 @@ def list_source(organization_id):
     for i, source in enumerate(client.list_sources(request={"parent": org_name})):
         print(i, source)
     # [END list_sources]
+    # [END securitycenter_list_sources]
     return i
 
 
 def create_finding(source_name):
     """Creates a new finding."""
+    # [START securitycenter_create_finding]
     # [START create_finding]
     from google.cloud import securitycenter
     from google.cloud.securitycenter_v1 import CreateFindingRequest, Finding
@@ -193,11 +204,13 @@ def create_finding(source_name):
     )
     print(created_finding)
     # [END create_finding]
+    # [END securitycenter_create_finding]
     return created_finding
 
 
 def create_finding_with_source_properties(source_name):
     """Demonstrate creating a new finding with source properties. """
+    # [START securitycenter_create_finding_with_properties]
     # [START create_finding_with_properties]
     import datetime
 
@@ -249,9 +262,11 @@ def create_finding_with_source_properties(source_name):
     )
     print(created_finding)
     # [END create_finding_with_properties]
+    # [END securitycenter_create_finding_with_properties]
 
 
 def update_finding(source_name):
+    # [START securitycenter_update_finding]
     # [START update_finding]
     import datetime
 
@@ -295,10 +310,12 @@ def update_finding(source_name):
         )
     )
     # [END update_finding]
+    # [END securitycenter_update_finding]
 
 
 def update_finding_state(source_name):
     """Demonstrate updating only a finding state."""
+    # [START securitycenter_update_finding_state]
     # [START update_finding_state]
     import datetime
 
@@ -324,11 +341,13 @@ def update_finding_state(source_name):
     )
     print(f"New state: {new_finding.state}")
     # [END update_finding_state]
+    # [END securitycenter_update_finding_state]
 
 
 def trouble_shoot(source_name):
     """Demonstrate calling test_iam_permissions to determine if the
     service account has the correct permisions."""
+    # [START securitycenter_test_iam_permissions]
     # [START test_iam_permissions]
     from google.cloud import securitycenter
 
@@ -355,7 +374,9 @@ def trouble_shoot(source_name):
         )
     )
     # [END test_iam_permissions]
+    # [END securitycenter_test_iam_permissions]
     assert len(permission_response.permissions) > 0
+    # [START securitycenter_test_iam_permissions]
     # [START test_iam_permissions]
     # Check for permissions necessary to call set_finding_state.
     permission_response = client.test_iam_permissions(
@@ -368,11 +389,13 @@ def trouble_shoot(source_name):
         "Permision to update state? {}".format(len(permission_response.permissions) > 0)
     )
     # [END test_iam_permissions]
+    # [END securitycenter_test_iam_permissions]
     return permission_response
     assert len(permission_response.permissions) > 0
 
 
 def list_all_findings(organization_id):
+    # [START securitycenter_list_all_findings]
     # [START list_all_findings]
     from google.cloud import securitycenter
 
@@ -393,10 +416,12 @@ def list_all_findings(organization_id):
             )
         )
     # [END list_all_findings]
+    # [END securitycenter_list_all_findings]
     return i
 
 
 def list_filtered_findings(source_name):
+    # [START securitycenter_list_filtered_findings]
     # [START list_filtered_findings]
     from google.cloud import securitycenter
 
@@ -423,10 +448,12 @@ def list_filtered_findings(source_name):
             )
         )
     # [END list_filtered_findings]
+    # [END securitycenter_list_filtered_findings]
     return i
 
 
 def list_findings_at_time(source_name):
+    # [START securitycenter_list_findings_at_a_time]
     # [START list_findings_at_a_time]
     from google.cloud import securitycenter
     from datetime import timedelta, datetime
@@ -444,7 +471,9 @@ def list_findings_at_time(source_name):
     #   source_name = "organizations/111122222444/sources/-"
     five_days_ago = str(datetime.now() - timedelta(days=5))
     # [END list_findings_at_a_time]
+    # [END securitycenter_]
     i = -1
+    # [START securitycenter_list_findings_at_a_time]
     # [START list_findings_at_a_time]
 
     finding_result_iterator = client.list_findings(
@@ -457,11 +486,13 @@ def list_findings_at_time(source_name):
             )
         )
     # [END list_findings_at_a_time]
+    # [END securitycenter_list_findings_at_a_time]
     return i
 
 
 def get_iam_policy(source_name):
     """Gives a user findingsEditor permission to the source."""
+    # [START securitycenter_get_source_iam]
     # [START get_source_iam]
     from google.cloud import securitycenter
 
@@ -477,11 +508,13 @@ def get_iam_policy(source_name):
     policy = client.get_iam_policy(request={"resource": source_name})
     print("Policy: {}".format(policy))
     # [END get_source_iam]
+    # [END securitycenter_get_source_iam]
 
 
 def group_all_findings(organization_id):
     """Demonstrates grouping all findings across an organization."""
     i = 0
+    # [START securitycenter_group_all_findings]
     # [START group_all_findings]
     from google.cloud import securitycenter
 
@@ -500,13 +533,14 @@ def group_all_findings(organization_id):
     for i, group_result in enumerate(group_result_iterator):
         print((i + 1), group_result)
     # [END group_all_findings]
+    # [END securitycenter_group_all_findings]
     return i
 
 
 def group_filtered_findings(source_name):
     """Demonstrates grouping all findings across an organization."""
     i = 0
-    # [START group_filtered_findings]
+    # [START securitycenter_group_filtered_findings]
     from google.cloud import securitycenter
 
     # Create a client.
@@ -528,7 +562,7 @@ def group_filtered_findings(source_name):
     )
     for i, group_result in enumerate(group_result_iterator):
         print((i + 1), group_result)
-    # [END group_filtered_findings]
+    # [END securitycenter_group_filtered_findings]
     return i
 
 
@@ -536,7 +570,7 @@ def group_findings_at_time(source_name):
     """Demonstrates grouping all findings across an organization as of
     a specific time."""
     i = -1
-    # [START group_findings_at_time]
+    # [START securitycenter_group_findings_at_time]
     from datetime import datetime, timedelta
     from google.cloud import securitycenter
 
@@ -562,7 +596,7 @@ def group_findings_at_time(source_name):
     )
     for i, group_result in enumerate(group_result_iterator):
         print((i + 1), group_result)
-    # [END group_findings_at_time]
+    # [END securitycenter_group_findings_at_time]
     return i
 
 
@@ -570,7 +604,7 @@ def group_findings_and_changes(source_name):
     """Demonstrates grouping all findings across an organization and
     associated changes."""
     i = 0
-    # [START group_findings_with_changes]
+    # [START securitycenter_group_findings_with_changes]
     from datetime import timedelta
 
     from google.cloud import securitycenter
@@ -597,5 +631,5 @@ def group_findings_and_changes(source_name):
     )
     for i, group_result in enumerate(group_result_iterator):
         print((i + 1), group_result)
-    # [END group_findings_with_changes]
+    # [END securitycenter_group_findings_with_changes]]
     return i

--- a/samples/snippets/snippets_findings.py
+++ b/samples/snippets/snippets_findings.py
@@ -471,7 +471,7 @@ def list_findings_at_time(source_name):
     #   source_name = "organizations/111122222444/sources/-"
     five_days_ago = str(datetime.now() - timedelta(days=5))
     # [END list_findings_at_a_time]
-    # [END securitycenter_]
+    # [END securitycenter_list_findings_at_a_time]
     i = -1
     # [START securitycenter_list_findings_at_a_time]
     # [START list_findings_at_a_time]

--- a/samples/snippets/snippets_list_assets.py
+++ b/samples/snippets/snippets_list_assets.py
@@ -20,6 +20,7 @@
 def list_all_assets(organization_id):
     """Demonstrate listing and printing all assets."""
     i = 0
+    # [START securitycenter_demo_list_all_assets]
     # [START demo_list_all_assets]
     from google.cloud import securitycenter
 
@@ -33,12 +34,14 @@ def list_all_assets(organization_id):
     for i, asset_result in enumerate(asset_iterator):
         print(i, asset_result)
     # [END demo_list_all_assets]
+    # [END securitycenter_demo_list_all_assets]
     return i
 
 
 def list_assets_with_filters(organization_id):
     """Demonstrate listing assets with a filter."""
     i = 0
+    # [START securitycenter_demo_list_assets_with_filter]
     # [START demo_list_assets_with_filter]
     from google.cloud import securitycenter
 
@@ -59,12 +62,14 @@ def list_assets_with_filters(organization_id):
     for i, asset_result in enumerate(asset_iterator):
         print(i, asset_result)
     # [END demo_list_assets_with_filter]
+    # [END securitycenter_demo_list_assets_with_filter]
     return i
 
 
 def list_assets_with_filters_and_read_time(organization_id):
     """Demonstrate listing assets with a filter."""
     i = 0
+    # [START securitycenter_demo_list_assets_with_filter_and_time]
     # [START demo_list_assets_with_filter_and_time]
     from datetime import datetime, timedelta
 
@@ -95,12 +100,14 @@ def list_assets_with_filters_and_read_time(organization_id):
     for i, asset_result in enumerate(asset_iterator):
         print(i, asset_result)
     # [END demo_list_assets_with_filter_and_time]
+    # [END securitycenter_demo_list_assets_with_filter_and_time]
     return i
 
 
 def list_point_in_time_changes(organization_id):
     """Demonstrate listing assets along with their state changes."""
     i = 0
+    # [START securitycenter_demo_list_assets_changes]
     # [START demo_list_assets_changes]
     from datetime import timedelta
 
@@ -131,13 +138,14 @@ def list_point_in_time_changes(organization_id):
         print(i, asset)
 
     # [END demo_list_assets_changes]
+    # [END securitycenter_demo_list_assets_changes]
     return i
 
 
 def group_assets(organization_id):
     """Demonstrates grouping all assets by type. """
     i = 0
-    # [START group_all_assets]
+    # [START securitycenter_group_all_assets]
     from google.cloud import securitycenter
 
     client = securitycenter.SecurityCenterClient()
@@ -153,14 +161,14 @@ def group_assets(organization_id):
     )
     for i, result in enumerate(result_iterator):
         print((i + 1), result)
-    # [END group_all_assets]
+    # [END securitycenter_group_all_assets]
     return i
 
 
 def group_filtered_assets(organization_id):
     """Demonstrates grouping assets by type with a filter. """
     i = 0
-    # [START group_all_assets_with_filter]
+    # [START securitycenter_group_all_assets_with_filter]
     from google.cloud import securitycenter
 
     client = securitycenter.SecurityCenterClient()
@@ -179,7 +187,7 @@ def group_filtered_assets(organization_id):
     )
     for i, result in enumerate(result_iterator):
         print((i + 1), result)
-    # [END group_all_assets_with_filter]
+    # [END securitycenter_group_all_assets_with_filter]
     # only one asset type is a project
     return i
 
@@ -187,7 +195,7 @@ def group_filtered_assets(organization_id):
 def group_assets_by_changes(organization_id):
     """Demonstrates grouping assets by their changes over a period of time."""
     i = 0
-    # [START group_all_assets_by_change]
+    # [START securitycenter_group_all_assets_by_change]
     from datetime import timedelta
 
     from google.cloud import securitycenter
@@ -208,5 +216,5 @@ def group_assets_by_changes(organization_id):
     )
     for i, result in enumerate(result_iterator):
         print((i + 1), result)
-    # [END group_all_assets_by_change]
+    # [END securitycenter_group_all_assets_by_change]
     return i

--- a/samples/snippets/snippets_notification_configs.py
+++ b/samples/snippets/snippets_notification_configs.py
@@ -18,6 +18,7 @@
 
 def create_notification_config(organization_id, notification_config_id, pubsub_topic):
 
+    # [START securitycenter_create_notification_config]
     # [START scc_create_notification_config]
     from google.cloud import securitycenter as securitycenter
 
@@ -44,11 +45,13 @@ def create_notification_config(organization_id, notification_config_id, pubsub_t
 
     print(created_notification_config)
     # [END scc_create_notification_config]
+    # [END securitycenter_create_notification_config]
     return created_notification_config
 
 
 def delete_notification_config(organization_id, notification_config_id):
 
+    # [START securitycenter_delete_notification_config]
     # [START scc_delete_notification_config]
     from google.cloud import securitycenter as securitycenter
 
@@ -64,11 +67,13 @@ def delete_notification_config(organization_id, notification_config_id):
     client.delete_notification_config(request={"name": notification_config_name})
     print("Deleted notification config: {}".format(notification_config_name))
     # [END scc_delete_notification_config]
+    # [END securitycenter_delete_notification_config]
     return True
 
 
 def get_notification_config(organization_id, notification_config_id):
 
+    # [START securitycenter_get_notification_config]
     # [START scc_get_notification_config]
     from google.cloud import securitycenter as securitycenter
 
@@ -86,11 +91,13 @@ def get_notification_config(organization_id, notification_config_id):
     )
     print("Got notification config: {}".format(notification_config))
     # [END scc_get_notification_config]
+    # [END securitycenter_get_notification_config]
     return notification_config
 
 
 def list_notification_configs(organization_id):
 
+    # [START securitycenter_list_notification_configs]
     # [START scc_list_notification_configs]
     from google.cloud import securitycenter as securitycenter
 
@@ -105,10 +112,12 @@ def list_notification_configs(organization_id):
     for i, config in enumerate(notification_configs_iterator):
         print("{}: notification_config: {}".format(i, config))
     # [END scc_list_notification_configs]
+    # [END securitycenter_list_notification_configs]]
     return notification_configs_iterator
 
 
 def update_notification_config(organization_id, notification_config_id, pubsub_topic):
+    # [START securitycenter_update_notification_config]
     # [START scc_update_notification_config]
     from google.cloud import securitycenter as securitycenter
     from google.protobuf import field_mask_pb2
@@ -147,4 +156,5 @@ def update_notification_config(organization_id, notification_config_id, pubsub_t
 
     print(updated_notification_config)
     # [END scc_update_notification_config]
+    # [END securitycenter_update_notification_config]
     return updated_notification_config

--- a/samples/snippets/snippets_notification_receiver.py
+++ b/samples/snippets/snippets_notification_receiver.py
@@ -17,6 +17,7 @@
 
 
 def receive_notifications(project_id, subscription_name):
+    # [START securitycenter_receive_notifications]
     # [START scc_receive_notifications]
     # Requires https://cloud.google.com/pubsub/docs/quickstart-client-libraries#pubsub-client-libraries-python
     import concurrent
@@ -53,4 +54,5 @@ def receive_notifications(project_id, subscription_name):
     except concurrent.futures.TimeoutError:
         streaming_pull_future.cancel()
     # [END scc_receive_notifications]
+    # [END securitycenter_receive_notifications]
     return True

--- a/samples/snippets/snippets_orgs.py
+++ b/samples/snippets/snippets_orgs.py
@@ -33,6 +33,7 @@ def get_settings(organization_id):
     # [END get_org_settings]
     # [END securitycenter_get_org_settings]
 
+
 def update_asset_discovery_org_settings(organization_id):
     """Example showing how to update the asset discovery configuration
     for an organization."""

--- a/samples/snippets/snippets_orgs.py
+++ b/samples/snippets/snippets_orgs.py
@@ -18,6 +18,7 @@
 
 def get_settings(organization_id):
     """Example showing how to retreive current organization settings."""
+    # [START securitycenter_get_org_settings]
     # [START get_org_settings]
     from google.cloud import securitycenter
 
@@ -30,11 +31,12 @@ def get_settings(organization_id):
     org_settings = client.get_organization_settings(request={"name": org_settings_name})
     print(org_settings)
     # [END get_org_settings]
-
+    # [END securitycenter_get_org_settings]
 
 def update_asset_discovery_org_settings(organization_id):
     """Example showing how to update the asset discovery configuration
     for an organization."""
+    # [START securitycenter_update_org_settings]
     # [START update_org_settings]
     from google.cloud import securitycenter
     from google.protobuf import field_mask_pb2
@@ -60,4 +62,5 @@ def update_asset_discovery_org_settings(organization_id):
     )
     print("Asset Discovery Enabled? {}".format(updated.enable_asset_discovery))
     # [END update_org_settings]
+    # [END securitycenter_update_org_settings]
     return updated

--- a/samples/snippets/snippets_security_marks.py
+++ b/samples/snippets/snippets_security_marks.py
@@ -18,6 +18,7 @@
 
 def add_to_asset(asset_name):
     """Add new security marks to an asset."""
+    # [START securitycenter_add_marks_to_asset]
     # [START add_marks_to_asset]
     from google.cloud import securitycenter
     from google.protobuf import field_mask_pb2
@@ -44,6 +45,7 @@ def add_to_asset(asset_name):
     )
     print(updated_marks)
     # [END add_marks_to_asset]
+    # [END securitycenter_add_marks_to_asset]
     return updated_marks, marks
 
 
@@ -51,6 +53,7 @@ def clear_from_asset(asset_name):
     """Removes security marks from an asset."""
     # Make sure they are there first
     add_to_asset(asset_name)
+    # [START securitycenter_clear_marks_asset]
     # [START clear_marks_asset]
     from google.cloud import securitycenter
     from google.protobuf import field_mask_pb2
@@ -78,6 +81,7 @@ def clear_from_asset(asset_name):
     )
     print(updated_marks)
     # [END clear_marks_asset]
+    # [END securitycenter_clear_marks_asset]
     return updated_marks
 
 
@@ -85,6 +89,7 @@ def delete_and_update_marks(asset_name):
     """Updates and deletes security marks from an asset in the same call."""
     # Make sure they are there first
     add_to_asset(asset_name)
+    # [START securitycenter_delete_and_update_marks]
     # [START delete_and_update_marks]
     from google.cloud import securitycenter
     from google.protobuf import field_mask_pb2
@@ -107,11 +112,13 @@ def delete_and_update_marks(asset_name):
     )
     print(updated_marks)
     # [END delete_and_update_marks]
+    # [END securitycenter_delete_and_update_marks]
     return updated_marks
 
 
 def add_to_finding(finding_name):
     """Adds security marks to a finding. """
+    # [START securitycenter_add_marks_to_finding]
     # [START add_marks_to_finding]
     from google.cloud import securitycenter
     from google.protobuf import field_mask_pb2
@@ -138,6 +145,7 @@ def add_to_finding(finding_name):
         }
     )
     # [END add_marks_to_finding]
+    # [END securitycenter_add_marks_to_finding]
     return updated_marks, marks
 
 
@@ -145,6 +153,7 @@ def list_assets_with_query_marks(organization_id, asset_name):
     """Lists assets with a filter on security marks. """
     add_to_asset(asset_name)
     i = -1
+    # [START securitycenter_]
     # [START demo_list_assets_with_security_marks]
     from google.cloud import securitycenter
 
@@ -167,6 +176,7 @@ def list_assets_with_query_marks(organization_id, asset_name):
     for i, asset_result in enumerate(asset_iterator):
         print(i, asset_result)
     # [END demo_list_assets_with_security_marks]
+    # [END securitycenter_]
     return i
 
 
@@ -175,6 +185,7 @@ def list_findings_with_query_marks(source_name, finding_name):
     # ensure marks are set on finding.
     add_to_finding(finding_name)
     i = -1
+    # [START securitycenter_]
     # [START demo_list_findings_with_security_marks]
     from google.cloud import securitycenter
 
@@ -195,6 +206,7 @@ def list_findings_with_query_marks(source_name, finding_name):
     for i, finding_result in enumerate(finding_iterator):
         print(i, finding_result)
     # [END demo_list_findings_with_security_marks]
+    # [END securitycenter_]
     # one finding should have been updated with keys, and one should be
     # untouched.
     return i

--- a/samples/snippets/snippets_security_marks.py
+++ b/samples/snippets/snippets_security_marks.py
@@ -153,7 +153,7 @@ def list_assets_with_query_marks(organization_id, asset_name):
     """Lists assets with a filter on security marks. """
     add_to_asset(asset_name)
     i = -1
-    # [START securitycenter_]
+    # [START securitycenter_demo_list_assets_with_security_marks]
     # [START demo_list_assets_with_security_marks]
     from google.cloud import securitycenter
 
@@ -176,7 +176,7 @@ def list_assets_with_query_marks(organization_id, asset_name):
     for i, asset_result in enumerate(asset_iterator):
         print(i, asset_result)
     # [END demo_list_assets_with_security_marks]
-    # [END securitycenter_]
+    # [END securitycenter_demo_list_assets_with_security_marks]
     return i
 
 
@@ -185,7 +185,7 @@ def list_findings_with_query_marks(source_name, finding_name):
     # ensure marks are set on finding.
     add_to_finding(finding_name)
     i = -1
-    # [START securitycenter_]
+    # [START securitycenter_demo_list_findings_with_security_marks]
     # [START demo_list_findings_with_security_marks]
     from google.cloud import securitycenter
 
@@ -206,7 +206,7 @@ def list_findings_with_query_marks(source_name, finding_name):
     for i, finding_result in enumerate(finding_iterator):
         print(i, finding_result)
     # [END demo_list_findings_with_security_marks]
-    # [END securitycenter_]
+    # [END securitycenter_demo_list_findings_with_security_marks]
     # one finding should have been updated with keys, and one should be
     # untouched.
     return i


### PR DESCRIPTION
Standardizing Security Command Center samples to use 'securitycenter' prefixing. Wrapped existing samples to keep published doclinks unbroken, and fully replaced the ones that aren't published. Once this PR is through, published sample inclusions will be updated to use the new prefix, then I'll come through again and remove the unused block wraps.