### PR TITLE
test: log message.data for debugging

### DIFF
--- a/samples/snippets/snippets_notification_receiver.py
+++ b/samples/snippets/snippets_notification_receiver.py
@@ -29,8 +29,7 @@ def receive_notifications(project_id, subscription_name):
     # TODO: subscription_name = "your-subscription-name"
 
     def callback(message):
-        print("Received message")
-
+        
         # Print the data received for debugging purpose if needed
         print(f"Received message: {message.data}")
 

--- a/samples/snippets/snippets_notification_receiver.py
+++ b/samples/snippets/snippets_notification_receiver.py
@@ -32,7 +32,7 @@ def receive_notifications(project_id, subscription_name):
         print("Received message")
 
         # Print the data received for debugging purpose if needed
-        print(message.data)
+        print(f"Received message: {message.data}")
 
         notification_msg = NotificationMessage.from_json(message.data)
 

--- a/samples/snippets/snippets_notification_receiver.py
+++ b/samples/snippets/snippets_notification_receiver.py
@@ -29,7 +29,7 @@ def receive_notifications(project_id, subscription_name):
     # TODO: subscription_name = "your-subscription-name"
 
     def callback(message):
-        
+
         # Print the data received for debugging purpose if needed
         print(f"Received message: {message.data}")
 

--- a/samples/snippets/snippets_notification_receiver.py
+++ b/samples/snippets/snippets_notification_receiver.py
@@ -30,6 +30,9 @@ def receive_notifications(project_id, subscription_name):
 
     def callback(message):
         print("Received message")
+        
+        # Print the data received for debugging purpose if needed
+        print(message.data)
 
         notification_msg = NotificationMessage.from_json(message.data)
 

--- a/samples/snippets/snippets_notification_receiver.py
+++ b/samples/snippets/snippets_notification_receiver.py
@@ -30,7 +30,7 @@ def receive_notifications(project_id, subscription_name):
 
     def callback(message):
         print("Received message")
-        
+
         # Print the data received for debugging purpose if needed
         print(message.data)
 


### PR DESCRIPTION
Flaky test from #124 suggests that `message.data` might have been deformed somehow. 
Adding a logging for the data passed to help debug next time something goes wrong.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-securitycenter/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Updates #124 
