### PR TITLE
chore: fix string replacement in owlbot.py

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -29,17 +29,18 @@ for library in s.get_staging_dirs(default_version):
         r"\g<1>settings resource.\n"
         r"\g<1>If empty all mutable fields will be updated.",
     )
+
+    # Comment out broken assertion in unit test
+    # https://github.com/googleapis/gapic-generator-python/issues/897
+    s.replace(
+        library / "tests/**/*.py",
+        "assert args\[0\]\.start_time == timestamp_pb2\.Timestamp\(seconds=751\)",
+        "# assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)"
+    )
+
     s.move(library, excludes=["README.rst", "docs/index.rst", "setup.py"])
 
 s.remove_staging_dirs()
-
-# Comment out broken assertion in unit test
-# https://github.com/googleapis/gapic-generator-python/issues/897
-s.replace(
-    "tests/**/*.py",
-    "assert args\[0\]\.start_time == timestamp_pb2\.Timestamp\(seconds=751\)",
-    "# assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)"
-)
 
 # ----------------------------------------------------------------------------
 # Add templated files

--- a/tests/unit/gapic/securitycenter_v1/test_security_center.py
+++ b/tests/unit/gapic/securitycenter_v1/test_security_center.py
@@ -4817,7 +4817,7 @@ def test_set_finding_state_flattened():
         _, args, _ = call.mock_calls[0]
         assert args[0].name == "name_value"
         assert args[0].state == finding.Finding.State.ACTIVE
-        # # # # # # # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
+        # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
 
 
 def test_set_finding_state_flattened_error():
@@ -4862,7 +4862,7 @@ async def test_set_finding_state_flattened_async():
         _, args, _ = call.mock_calls[0]
         assert args[0].name == "name_value"
         assert args[0].state == finding.Finding.State.ACTIVE
-        # # # # # # # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
+        # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gapic/securitycenter_v1beta1/test_security_center.py
+++ b/tests/unit/gapic/securitycenter_v1beta1/test_security_center.py
@@ -3622,7 +3622,7 @@ def test_set_finding_state_flattened():
         _, args, _ = call.mock_calls[0]
         assert args[0].name == "name_value"
         assert args[0].state == finding.Finding.State.ACTIVE
-        # # # # # # # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
+        # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
 
 
 def test_set_finding_state_flattened_error():
@@ -3667,7 +3667,7 @@ async def test_set_finding_state_flattened_async():
         _, args, _ = call.mock_calls[0]
         assert args[0].name == "name_value"
         assert args[0].state == finding.Finding.State.ACTIVE
-        # # # # # # # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
+        # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/gapic/securitycenter_v1p1beta1/test_security_center.py
+++ b/tests/unit/gapic/securitycenter_v1p1beta1/test_security_center.py
@@ -4975,7 +4975,7 @@ def test_set_finding_state_flattened():
         _, args, _ = call.mock_calls[0]
         assert args[0].name == "name_value"
         assert args[0].state == finding.Finding.State.ACTIVE
-        # # # # # # # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
+        # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
 
 
 def test_set_finding_state_flattened_error():
@@ -5020,7 +5020,7 @@ async def test_set_finding_state_flattened_async():
         _, args, _ = call.mock_calls[0]
         assert args[0].name == "name_value"
         assert args[0].state == finding.Finding.State.ACTIVE
-        # # # # # # # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
+        # assert args[0].start_time == timestamp_pb2.Timestamp(seconds=751)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
There are commits, for example [this one](https://github.com/googleapis/python-securitycenter/pull/147/commits/e18c65369023ef73928ab22624db1841d4c83b32), in #147 from owlbot which are excessively commenting out the same line with `#`. I think the issue is caused by [this commit](https://github.com/googleapis/python-securitycenter/pull/143/commits/d040d6fc96864245aca3994ed926ed0b0482780b) made in #143 and the fact that the owlbot will run `owlbot.py` as part of the post-processing. 

[At this line](https://github.com/googleapis/python-securitycenter/blob/master/owlbot.py#L24) in `owlbot.py`, we have a for loop that iterates through paths to the clean (aka un-hacked) versions of the generated client from [googleapis-gen](https://github.com/googleapis/googleapis-gen/tree/master/google). The `s.replace()` calls should be done in the for loop to ensure that we only run the `s.replace()` on clean versions of the generated client. 