### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,12 @@ Python Client for Cloud Security Command Center API
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-securitycenter.svg
    :target: https://pypi.org/project/google-cloud-securitycenter/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-securitycenter.svg
    :target: https://pypi.org/project/google-cloud-securitycenter/
-.. _Alpha: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _Alpha: https://github.com/googleapis/google-cloud-python/blob/main/README.rst
 .. _Cloud Security Command Center API: https://cloud.google.com/security-command-center
 .. _Client Library Documentation: https://googleapis.dev/python/securitycenter/latest
 .. _Product Documentation:  https://cloud.google.com/security-command-center


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.