### PR TITLE
chore(deps): allow google-api-core v2 on v0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ description = "Cloud Security Command Center API API client library"
 version = "0.7.0"
 release_status = "Development Status :: 3 - Alpha"
 dependencies = [
-    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",
     "grpc-google-iam-v1 >= 0.12.3, < 0.13dev",
     'enum34; python_version < "3.4"',
 ]


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v0**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566