### PR TITLE
ci: fix release script

### DIFF
--- a/.kokoro/release.sh
+++ b/.kokoro/release.sh
@@ -16,7 +16,7 @@
 set -eo pipefail
 
 # Start the releasetool reporter
-python3 -m pip install --require-hashes -r .kokoro/requirements.txt
+python3 -m pip install --require-hashes -r github/python-securitycenter/.kokoro/requirements.txt
 python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /tmp/publisher-script
 
 # Disable buffering, so that the logs stream through.


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/googleapis/python-securitycenter/issues/377 where the release script failed with error `No such file or directory: '.kokoro/requirements.txt'`. See build log [here](https://fusion2.corp.google.com/invocations/5714116c-bad2-4d16-8e8e-d94ea7ec6280/targets/cloud-devrel%2Fclient-libraries%2Fpython%2Fgoogleapis%2Fpython-securitycenter%2Frelease%2Frelease/log). There was a recent change to the release script in https://github.com/googleapis/python-securitycenter/pull/376 which caused the issue. I added the `owlbot:ignore` as this change is made to a templated file. If the release succeeds, I'll open a PR to update the templated files.